### PR TITLE
REF: CMR-40, CMR-41 Add create/update fields to record.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ centralized_metadata-test
 
 # sqlite3 artifact
 ./centralized_metadata
+centralized_metadata

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -6,6 +6,11 @@ class RecordsController < ApplicationController
   # GET /records
   def index
     records = Record.all
+
+    records.each do |rec|
+      add_update_create_date_metadata!(rec)
+    end
+
     @records = records.map(&:value)
 
     render json: @records
@@ -13,6 +18,7 @@ class RecordsController < ApplicationController
 
   # GET /records/1
   def show
+    add_update_create_date_metadata!(@record)
     render json: @record.value
   end
 
@@ -49,4 +55,10 @@ class RecordsController < ApplicationController
     def record_params
       params.require(:record).permit(:id, :pref_label, :var_label, :local_pref_label, :local_var_label, :source_vocab, :import_method, :type, :see_also, :skos_exact_match, :skos_close_match, :lc_class, :local_note)
     end
+
+    def add_update_create_date_metadata!(record)
+      record.value["cm_created_at"] = record.created_at
+      record.value["cm_updated_at"] = record.updated_at
+    end
+
 end

--- a/spec/requests/record_spec.rb
+++ b/spec/requests/record_spec.rb
@@ -1,13 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe "Records", type: :request do
+  before do
+    file = fixture_file_upload("louis_armstrong.mrc")
+    post "/records", params: { marc_file: file }
+  end
 
   describe "POST /records" do
     it "returns http success" do
-      file = fixture_file_upload("louis_armstrong.mrc")
-      post "/records", params: { marc_file: file }
       expect(response).to have_http_status(:success)
     end
   end
 
+  describe "GET /records" do
+    it "gets records that contain a cm_updated_at and cm_created_at value " do
+      get "/records"
+      record = JSON.parse(response.body).first
+      expect(record).to have_key("cm_created_at")
+      expect(record).to have_key("cm_updated_at")
+    end
+  end
+
+  describe "GET /records/:id" do
+    it "gets a record that contains a cm_updated_at and cm_created_at value " do
+      get "/records/2043308"
+      record = JSON.parse(response.body)
+      expect(record).to have_key("cm_created_at")
+      expect(record).to have_key("cm_updated_at")
+    end
+  end
 end


### PR DESCRIPTION
Adds the cm_created_at and cm_updated_at field to record that is
presented to the user when they go to /records or records/:id path in
the app.