### PR TITLE
Add filename to indexer config specs.

### DIFF
--- a/spec/lib/centralized_metadata/indexer_config_spec.rb
+++ b/spec/lib/centralized_metadata/indexer_config_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Traject configuration" do
 
   before do
     indexer.load_config_file("lib/centralized_metadata/indexer_config.rb")
+    indexer.settings[:filename] = "foo.mrc"
   end
 
   describe "field cm_original_key" do


### PR DESCRIPTION
* fixes failing tests now that settings filename is required.

If it's not the case that it's required, there's another way to fix this issue.

Optional to #41 