### PR TITLE
Make default filename an empty string if not present.

### DIFF
--- a/lib/centralized_metadata/macros/custom.rb
+++ b/lib/centralized_metadata/macros/custom.rb
@@ -133,7 +133,7 @@ module CentralizedMetadata::Macros::Custom
 
   def add_source_vocab
     lambda do |rec, acc|
-      filename = @settings.dig(:original_filename) || @settings.dig(:filename)
+      filename = @settings.dig(:original_filename) || @settings.dig(:filename) || ""
       case
       when filename.include?("GNR")
         acc << "lcgft"


### PR DESCRIPTION
Fixes broken specs by not assumign that filename is require.

Defaults to a blank filename if filename not provided via settings.

Optional to #40 