### PR TITLE
Allow variable  marc_fields variable per context.

### DIFF
--- a/spec/lib/centralized_metadata/macros/custom_spec.rb
+++ b/spec/lib/centralized_metadata/macros/custom_spec.rb
@@ -341,9 +341,15 @@ RSpec.describe CentralizedMetadata::Macros::Custom do
   end
 
   describe "extract_marc_subfields" do
+    let(:marc_fields) { "383abcde" }
+
     before do
+      without_partial_double_verification do
+        allow(indexer).to receive(:marc_fields) { marc_fields }
+      end
+
       indexer.configure do
-        to_field "cm_music_num_designation", extract_marc_subfields("383abcde")
+        to_field "cm_music_num_designation", extract_marc_subfields(marc_fields)
       end
     end
 


### PR DESCRIPTION
This makes it so that we can test other scenarios a little easier.