### PR TITLE
Fix broken ingest of directory.

### DIFF
--- a/spec/lib/centralized_metadata/indexer_spec.rb
+++ b/spec/lib/centralized_metadata/indexer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CentralizedMetadata::Indexer do
   let (:indexer) { instance_double("Traject::Indexer::MarcIndexer") }
   let (:file) { instance_double(File) }
 
-  describe "ingest" do
+  describe "get_indexer" do
     before(:example) do
       allow(Traject::Indexer::MarcIndexer).to receive(:new).and_return(indexer)
       allow(indexer).to receive_messages(load_config_file: "", process: "")
@@ -16,7 +16,7 @@ RSpec.describe CentralizedMetadata::Indexer do
 
     context "When filepath is passed in with no extra options" do
       after(:example) do
-        CentralizedMetadata::Indexer.ingest("/path/to/file/myfile.mrc")
+        CentralizedMetadata::Indexer.get_indexer("/path/to/file/myfile.mrc")
       end
 
       it "loads indexer" do
@@ -33,7 +33,7 @@ RSpec.describe CentralizedMetadata::Indexer do
 
     context "when we add an overriding filename via the options" do
       after(:example) do
-        CentralizedMetadata::Indexer.ingest("/path/to/file/myfile.mrc", original_filename: "my_orignal_file.mrc")
+        CentralizedMetadata::Indexer.get_indexer("/path/to/file/myfile.mrc", original_filename: "my_orignal_file.mrc")
       end
 
       it "sets the original_filename inside the indexer settings" do


### PR DESCRIPTION
The indexing of directory is broken because traject does not allow reuse
of an indexer.

This changes the code to make and use a new indexer per file that is
being ingested.