### PR TITLE
Build swagger config with specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ rake  db:ingest[spec/fixtures/marc]
 This API uses [Rswag](https://github.com/rswag/rswag) to generate swagger documentation.  
 
 Existing documentation can be found in spec/requests/records_spec.rb. If you need to edit this file, be sure to run the `bundle exec rails rswag` command to run the updates.
+
+Do not update the swagger.yaml file by hand.  Use swagger tests to create it and also test the API.

--- a/spec/requests/records_spec.rb
+++ b/spec/requests/records_spec.rb
@@ -17,10 +17,12 @@ RSpec.describe "Records", type: :request do
   path '/records' do
     get('list records') do
       tags 'records'
+      produces "application/json"
       description "This web service returns records in a JSON format. 
       The pagination default is set to return 25 records at a time. If you would like to change this,
       add the parameter per_page=number_desired to the query parameters."
       response(200, 'successful') do        
+        schema "$ref" => "#/components/schemas/Records"
 
         let(:record) { JSON.parse(response.body).first }
 
@@ -30,6 +32,16 @@ RSpec.describe "Records", type: :request do
 
         it "returns http success" do
           expect(response).to have_http_status(:success)
+        end
+
+        it "gets records that contain a cm_updated_at and cm_created_at value " do
+          expect(record).to have_key("cm_created_at")
+          expect(record).to have_key("cm_updated_at")
+        end
+
+        it "gets records that contain a cm_filename" do
+          expect(record).to have_key("cm_filename")
+          expect(record["cm_filename"]).to eq(["louis_armstrong.mrc"])
         end
       end
     end
@@ -49,10 +61,11 @@ RSpec.describe "Records", type: :request do
       }
 
       description "This web service creates a new record. There are two methods for adding records.\n
-      Using a curl statement: curl -F 'marc_file=@spec/fixtures/marc/louis_armstrong.mrc' https://centralized-metada
-ta-qa.k8s.temple.edu \n
+      Using a curl statement: curl -F 'marc_file=@spec/fixtures/marc/louis_armstrong.mrc' https://centralized-metadata-qa.k8s.temple.edu \n
       Ingest with a rake task: rake db:ingest[spec/fixtures/marc]."
       response(200, 'successful') do
+        schema "$ref" => "#/components/schemas/Record"
+
         it "returns http success" do
           expect(response).to have_http_status(:success)
         end
@@ -65,39 +78,216 @@ ta-qa.k8s.temple.edu \n
     parameter name: 'id', in: :path, type: :string, description: 'id'
 
     get('show record') do
+      produces "application/json"
       tags 'records'
-      description "This web service returns an indivudual record in JSON format."
-      response(200, 'successful') do
-        let(:id) { '123' }
+      description "This web service returns an individual record in JSON format."
 
-        it "returns http success" do
-          expect(response).to have_http_status(:success)
+      response(200, 'successful') do
+        schema "$ref" => "#/components/schemas/Record"
+
+        it "gets a record that contains a cm_updated_at and cm_created_at value " do
+          get "/records/2043308"
+          record = JSON.parse(response.body)
+          expect(record).to have_key("cm_created_at")
+          expect(record).to have_key("cm_updated_at")
+          expect(record.dig("local_metadatum", "cm_local_pref_label")).to eq("test_pref")
+          expect(record.dig("local_metadatum", "cm_local_var_label")).to eq(["test_var"])
+          expect(record.dig("local_metadatum", "cm_local_note")).to eq(["test_note"])
         end
       end
     end
 
     patch('update record') do
-      tags 'records'
-      description "This web service updates a record."
-      response(200, 'successful') do
-        let(:id) { '123' }
+      before do
+        Record.new(
+          id: "patch-test",
+          value: {
+            "cm_id"=>["patch-test"],
+            "cm_pref_label"=>["Armstrong, Louis, 1901-1971. prf"],
+            "cm_import_method"=>["MARC binary"],
+            "cm_type"=>["personal name"],
+            "cm_see_also"=>
+          ["Biographical and program notes by Stanley Dance ([2] p. : 1 port.) in container; personnel and original issue and matrix no. on container.",
+           "Louis Armstrong, trumpet and vocals, and his band."],
+          }.to_json
+        ).save!
+      end
 
-        it "returns http success" do
-          expect(response).to have_http_status(:success)
+      after do
+        Record.find_by(id: "patch-test").destroy!
+      end
+
+      tags 'records'
+      description 'This web service updates a record. But just the specific fields of the record "value" field. Use if you want to execute a partial update of a record.' 
+      consumes "application/json"
+      produces "application/json"
+
+      response(200, 'successful') do
+
+        context "A record is sent in as a payload in the request" do
+          let(:payload) { { cm_id: ["patch-test"], cm_type: ["foobar"] }.to_json }
+
+          it "should only replace/update the specific fields in the payload" do
+
+            patch "/records/patch-test", params: payload , headers: { 'Content-Type' => 'application/json' }
+
+            expect(response).to be_successful
+            data = JSON.parse(body)
+            expect(data.except("cm_updated_at", "cm_created_at", "local_metadatum")).to eq({
+              "cm_id"=>["patch-test"],
+              "cm_pref_label"=>["Armstrong, Louis, 1901-1971. prf"],
+              "cm_import_method"=>["MARC binary"],
+              "cm_type"=>["foobar"],
+              "cm_see_also"=>
+              ["Biographical and program notes by Stanley Dance ([2] p. : 1 port.) in container; personnel and original issue and matrix no. on container.",
+               "Louis Armstrong, trumpet and vocals, and his band."],
+            })
+          end
         end
       end
+
+      response(422, 'unsuccessful') do
+        context "not sending required field in API call" do
+          it "should errror out because we need something to update to" do
+            put "/records/patch-test"
+            expect(response.status).to eq(422)
+
+            data = JSON.parse(body)
+            expect(data["params"]).to eq(["param is missing or the value is empty: cm_id"])
+          end
+        end
+
+        context "not having required cm_id value" do
+          let(:payload) { {}.to_json }
+
+          it "should error out because the cm_id value is required" do
+            put "/records/patch-test", params: payload , headers: { 'Content-Type' => 'application/json' }
+            expect(response.status).to eq(422)
+
+            data = JSON.parse(body)
+            expect(data["params"]).to eq(["param is missing or the value is empty: cm_id"])
+          end
+
+          context "cm_id value is not equal to :id in records/:id path" do
+            let(:payload) { { cm_id: ["not-patch-test"], cm_type: ["foobar"] }.to_json }
+
+            it "should error out because the value of the cm_id field to be updated should match the path id" do
+              put "/records/patch-test", params: payload , headers: { 'Content-Type' => 'application/json' }
+              expect(response.status).to eq(422)
+
+              data = JSON.parse(body)
+              expect(data["cm_id"]).to eq(["The :cm_id and :id values must match."])
+            end
+          end
+
+        end
+      end
+
+      consumes "application/json"
+      parameter name: :Record, required: true,
+        in: :body, description: 'The value section of the centralized-metadata record',
+        schema: { "$ref" => "#/components/schemas/Record" }
+
+      request_body_example name: "example1", value: {
+        cm_id: ["fst01423682"],
+        cm_pref_label: ["Abbreviations of titles"],
+        cm_source_vocab: ["lcgft"],
+        cm_import_method: ["MARC binary"],
+        cm_filename: ["TEUM_CNS_GNR.mrc"],
+        cm_type: ["genre"],
+      }
     end
 
     put('update record') do
-      tags 'records'
-      description "This web service updates a record."
-      response(200, 'successful') do
-        let(:id) { '123' }
+      before do
+        Record.new(
+          id: "put-test",
+          value: {
+            "cm_id"=>["put-test"],
+            "cm_pref_label"=>["Armstrong, Louis, 1901-1971. prf"],
+            "cm_import_method"=>["MARC binary"],
+            "cm_type"=>["personal name"],
+            "cm_see_also"=>
+          ["Biographical and program notes by Stanley Dance ([2] p. : 1 port.) in container; personnel and original issue and matrix no. on container.",
+           "Louis Armstrong, trumpet and vocals, and his band."],
+          }.to_json
+        ).save!
+      end
 
-        it "returns http success" do
-          expect(response).to have_http_status(:success)
+      after do
+        Record.find_by(id: "put-test").destroy!
+      end
+
+      tags 'records'
+
+      description "This web service updates a record."
+
+      consumes "application/json"
+      produces "application/json"
+
+      response(200, 'successful') do
+        context "A record is sent in as a payload in the request" do
+          let(:payload) { { cm_id: ["put-test"], cm_type: ["foobar"] }.to_json }
+
+          it "should completely replace the value or the record in the database with the updated value" do
+
+            put "/records/put-test", params: payload , headers: { 'Content-Type' => 'application/json' }
+
+            expect(response).to be_successful
+            data = JSON.parse(body)
+            expect(data.except("cm_updated_at", "cm_created_at", "local_metadatum")).to eq(JSON.parse(payload))
+          end
         end
       end
+
+      response(422, 'unsuccessful') do
+        context "not sending required field in API call" do
+          it "should errror out because we need something to update to" do
+            put "/records/put-test"
+            expect(response.status).to eq(422)
+
+            data = JSON.parse(body)
+            expect(data["params"]).to eq(["param is missing or the value is empty: cm_id"])
+          end
+        end
+
+        context "not having required cm_id value" do
+          let(:payload) { {}.to_json }
+
+          it "should error out because the cm_id value is required" do
+            put "/records/put-test", params: payload , headers: { 'Content-Type' => 'application/json' }
+            expect(response.status).to eq(422)
+
+            data = JSON.parse(body)
+            expect(data["params"]).to eq(["param is missing or the value is empty: cm_id"])
+          end
+        end
+
+        context "cm_id value is not equal to :id in records/:id path" do
+          let(:payload) { { cm_id: ["not-put-test"], cm_type: ["foobar"] }.to_json }
+
+          it "should error out because the value of the cm_id field to be updated should match the path id" do
+            put "/records/put-test", params: payload , headers: { 'Content-Type' => 'application/json' }
+            expect(response.status).to eq(422)
+
+            data = JSON.parse(body)
+            expect(data["cm_id"]).to eq(["The :cm_id and :id values must match."])
+          end
+        end
+      end
+
+      parameter name: :Record, required: true,
+        in: :body, description: 'The value section of the centralized-metadata record',
+        schema: { "$ref" => "#/components/schemas/Record" }
+
+      request_body_example name: "example1", value: {
+        cm_id: ["fst01423682"],
+        cm_pref_label: ["Abbreviations of titles"],
+        cm_source_vocab: ["lcgft"],
+        cm_import_method: ["MARC binary"],
+        cm_filename: ["TEUM_CNS_GNR.mrc"],
+        cm_type: ["genre"],
+      }
     end
 
     delete('delete record') do
@@ -113,179 +303,4 @@ ta-qa.k8s.temple.edu \n
     end
   end
 
-  describe "GET /records" do
-    let(:record) { JSON.parse(response.body).first }
-
-    before do
-      get "/records"
-    end
-
-    it "gets records that contain a cm_updated_at and cm_created_at value " do
-      expect(record).to have_key("cm_created_at")
-      expect(record).to have_key("cm_updated_at")
-    end
-
-    it "gets records that contain a cm_filename" do
-      expect(record).to have_key("cm_filename")
-      expect(record["cm_filename"]).to eq(["louis_armstrong.mrc"])
-    end
-  end
-
-  describe "GET /records/:id" do
-    it "gets a record that contains a cm_updated_at and cm_created_at value " do
-      get "/records/2043308"
-      record = JSON.parse(response.body)
-      expect(record).to have_key("cm_created_at")
-      expect(record).to have_key("cm_updated_at")
-      expect(record.dig("local_metadatum", "cm_local_pref_label")).to eq("test_pref")
-      expect(record.dig("local_metadatum", "cm_local_var_label")).to eq(["test_var"])
-      expect(record.dig("local_metadatum", "cm_local_note")).to eq(["test_note"])
-    end
-  end
-
-  describe "PUT /records/:id" do
-    before do
-      Record.new(
-        id: "put-test",
-        value: {
-          "cm_id"=>["put-test"],
-          "cm_pref_label"=>["Armstrong, Louis, 1901-1971. prf"],
-          "cm_import_method"=>["MARC binary"],
-          "cm_type"=>["personal name"],
-          "cm_see_also"=>
-        ["Biographical and program notes by Stanley Dance ([2] p. : 1 port.) in container; personnel and original issue and matrix no. on container.",
-         "Louis Armstrong, trumpet and vocals, and his band."],
-        }.to_json
-      ).save!
-    end
-
-    after do
-      Record.find_by(id: "put-test").destroy!
-    end
-
-
-    context "not sending required field in API call" do
-      it "should errror out because we need something to update to" do
-        put "/records/put-test"
-        expect(response.status).to eq(422)
-
-        data = JSON.parse(body)
-        expect(data["params"]).to eq(["param is missing or the value is empty: cm_id"])
-      end
-    end
-
-    context "not having required cm_id value" do
-      let(:payload) { {}.to_json }
-
-      it "should error out because the cm_id value is required" do
-        put "/records/put-test", params: payload , headers: { 'Content-Type' => 'application/json' }
-        expect(response.status).to eq(422)
-
-        data = JSON.parse(body)
-        expect(data["params"]).to eq(["param is missing or the value is empty: cm_id"])
-      end
-    end
-
-    context "cm_id value is not equal to :id in records/:id path" do
-      let(:payload) { { cm_id: ["not-put-test"], cm_type: ["foobar"] }.to_json }
-
-      it "should error out because the value of the cm_id field to be updated should match the path id" do
-        put "/records/put-test", params: payload , headers: { 'Content-Type' => 'application/json' }
-        expect(response.status).to eq(422)
-
-        data = JSON.parse(body)
-        expect(data["cm_id"]).to eq(["The :cm_id and :id values must match."])
-      end
-    end
-
-
-    context "A record is sent in as a payload in the request" do
-      let(:payload) { { cm_id: ["put-test"], cm_type: ["foobar"] }.to_json }
-
-      it "should completely replace the value or the record in the database with the updated value" do
-
-        put "/records/put-test", params: payload , headers: { 'Content-Type' => 'application/json' }
-
-        expect(response).to be_successful
-        data = JSON.parse(body)
-        expect(data.except("cm_updated_at", "cm_created_at", "local_metadatum")).to eq(JSON.parse(payload))
-      end
-    end
-  end
-
-  describe "PATCH /records/:id" do
-    before do
-      Record.new(
-        id: "patch-test",
-        value: {
-          "cm_id"=>["patch-test"],
-          "cm_pref_label"=>["Armstrong, Louis, 1901-1971. prf"],
-          "cm_import_method"=>["MARC binary"],
-          "cm_type"=>["personal name"],
-          "cm_see_also"=>
-        ["Biographical and program notes by Stanley Dance ([2] p. : 1 port.) in container; personnel and original issue and matrix no. on container.",
-         "Louis Armstrong, trumpet and vocals, and his band."],
-        }.to_json
-      ).save!
-    end
-
-    after do
-      Record.find_by(id: "patch-test").destroy!
-    end
-
-    context "not sending required field in API call" do
-      it "should errror out because we need something to update to" do
-        put "/records/patch-test"
-        expect(response.status).to eq(422)
-
-        data = JSON.parse(body)
-        expect(data["params"]).to eq(["param is missing or the value is empty: cm_id"])
-      end
-    end
-
-    context "not having required cm_id value" do
-      let(:payload) { {}.to_json }
-
-      it "should error out because the cm_id value is required" do
-        put "/records/patch-test", params: payload , headers: { 'Content-Type' => 'application/json' }
-        expect(response.status).to eq(422)
-
-        data = JSON.parse(body)
-        expect(data["params"]).to eq(["param is missing or the value is empty: cm_id"])
-      end
-    end
-
-    context "cm_id value is not equal to :id in records/:id path" do
-      let(:payload) { { cm_id: ["not-patch-test"], cm_type: ["foobar"] }.to_json }
-
-      it "should error out because the value of the cm_id field to be updated should match the path id" do
-        put "/records/patch-test", params: payload , headers: { 'Content-Type' => 'application/json' }
-        expect(response.status).to eq(422)
-
-        data = JSON.parse(body)
-        expect(data["cm_id"]).to eq(["The :cm_id and :id values must match."])
-      end
-    end
-
-    context "A record is sent in as a payload in the request" do
-      let(:payload) { { cm_id: ["patch-test"], cm_type: ["foobar"] }.to_json }
-
-      it "should only replace/update the specific fields in the payload" do
-
-        patch "/records/patch-test", params: payload , headers: { 'Content-Type' => 'application/json' }
-
-        expect(response).to be_successful
-        data = JSON.parse(body)
-        expect(data.except("cm_updated_at", "cm_created_at", "local_metadatum")).to eq({
-          "cm_id"=>["patch-test"],
-          "cm_pref_label"=>["Armstrong, Louis, 1901-1971. prf"],
-          "cm_import_method"=>["MARC binary"],
-          "cm_type"=>["foobar"],
-          "cm_see_also"=>
-        ["Biographical and program notes by Stanley Dance ([2] p. : 1 port.) in container; personnel and original issue and matrix no. on container.",
-         "Louis Armstrong, trumpet and vocals, and his band."],
-        })
-      end
-    end
-  end
 end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'centralized_metadata'
 
 RSpec.configure do |config|
   # Specify a root folder where Swagger JSON files are generated
@@ -44,9 +45,30 @@ RSpec.configure do |config|
               default: 'centralized-metadata-qa.k8s.temple.edu'
             }
           }
+        }],
+
+        components: {
+          schemas: {
+            Record: {
+              type: "object",
+              required: %w(cm_id),
+              properties: CentralizedMetadata::Indexer.fields.reduce({}) { |acc, f|
+                acc.merge("#{f}": {
+                  type: "array",
+                  items: { type: "string" },
+                })
+              }
+            },
+            Records: {
+              type: "array",
+              items: { "$ref" => "#/components/schemas/Record" }
+            }
+          }
         }
-      ]
+
     }
+
+
   }
 
   # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -16,6 +16,10 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Records"
     post:
       summary: create record
       tags:
@@ -28,6 +32,10 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Record"
       requestBody:
         content:
           multipart/form-data:
@@ -55,59 +63,80 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Record"
     patch:
       summary: update record
       tags:
       - records
-      description: This web service updates a record. But just the specific fields of the record "value" field. Use if you want to execute a partial update of a record.
+      description: This web service updates a record. But just the specific fields
+        of the record "value" field. Use if you want to execute a partial update of
+        a record.
+      parameters: []
       responses:
-        '422':
-          description: unsuccesful
         '200':
           description: successful
+        '422':
+          description: unsuccessful
       requestBody:
-        required: true
         content:
           application/json:
-            description: The value section of the centralized-metatadata record.
             schema:
-              $ref: "#/components/schemas/RecordPatchPutPayload"
+              "$ref": "#/components/schemas/Record"
             examples:
               example1:
+                summary: update record
                 value:
-                  cm_id: ["fst01423682"]
-                  cm_pref_label: ["Abbreviations of titles"]
-                  cm_source_vocab: ["lcgft"]
-                  cm_import_method: ["MARC binary"]
-                  cm_filename: ["TEUM_CNS_GNR.mrc"]
-                  cm_type: ["genre"]
-
+                  cm_id:
+                  - fst01423682
+                  cm_pref_label:
+                  - Abbreviations of titles
+                  cm_source_vocab:
+                  - lcgft
+                  cm_import_method:
+                  - MARC binary
+                  cm_filename:
+                  - TEUM_CNS_GNR.mrc
+                  cm_type:
+                  - genre
+        required: true
+        description: The value section of the centralized-metadata record
     put:
       summary: update record
       tags:
       - records
-      description: This web service updates a record. Use if you want to update the entire value of the record with the payload.
+      description: This web service updates a record.
+      parameters: []
       responses:
-        '422':
-          description: unsuccesful
         '200':
           description: successful
+        '422':
+          description: unsuccessful
       requestBody:
-        required: true
         content:
           application/json:
-            description: The value section of the centralized-metatadata record.
             schema:
-              $ref: "#/components/schemas/RecordPatchPutPayload"
+              "$ref": "#/components/schemas/Record"
             examples:
               example1:
+                summary: update record
                 value:
-                  cm_id: ["fst01423682"]
-                  cm_pref_label: ["Abbreviations of titles"]
-                  cm_source_vocab: ["lcgft"]
-                  cm_import_method: ["MARC binary"]
-                  cm_filename: ["TEUM_CNS_GNR.mrc"]
-                  cm_type: ["genre"]
+                  cm_id:
+                  - fst01423682
+                  cm_pref_label:
+                  - Abbreviations of titles
+                  cm_source_vocab:
+                  - lcgft
+                  cm_import_method:
+                  - MARC binary
+                  cm_filename:
+                  - TEUM_CNS_GNR.mrc
+                  cm_type:
+                  - genre
+        required: true
+        description: The value section of the centralized-metadata record
     delete:
       summary: delete record
       tags:
@@ -116,7 +145,6 @@ paths:
       responses:
         '200':
           description: successful
-
 servers:
 - url: https://centralized-metadata-qa.k8s.temple.edu
 - url: http://localhost:3000
@@ -128,16 +156,16 @@ servers:
   variables:
     defaultHost:
       default: centralized-metadata-qa.k8s.temple.edu
-
 components:
   schemas:
-    RecordPatchPutPayload:
+    Record:
       type: object
-      required: [ "cm_id" ]
+      required:
+      - cm_id
       properties:
         cm_id:
           type: array
-          itmes:
+          items:
             type: string
         cm_pref_label:
           type: array
@@ -383,3 +411,7 @@ components:
           type: array
           items:
             type: string
+    Records:
+      type: array
+      items:
+        "$ref": "#/components/schemas/Record"


### PR DESCRIPTION
Recent changes to the swagger config have not been done via specs as required.  This change corrects that issue so that I can move forward with real API changes.