### PR TITLE
Update endpoints to return more information.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem "rspec-rails"
-  gem "rswag-specs"
   gem "byebug", platform: :mri
   gem "pry-rails"
   gem "capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,7 +311,6 @@ DEPENDENCIES
   rake
   rspec-rails
   rswag
-  rswag-specs
   sqlite3
   traject
   tzinfo-data

--- a/app/controllers/concerns/records_processed_count_header.rb
+++ b/app/controllers/concerns/records_processed_count_header.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module RecordsProcessedCountHeader
+  extend ActiveSupport::Concern
+
+  included do
+    after_action :set_records_processed_count_header, only: [:create, :delete]
+  end
+
+  def set_records_processed_count_header
+    response.headers["X-CM-Records-Processed-Count"] = @records.count
+  end
+end

--- a/app/controllers/concerns/total_records_count_header.rb
+++ b/app/controllers/concerns/total_records_count_header.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module TotalRecordsCountHeader
+  extend ActiveSupport::Concern
+
+  included do
+    after_action :set_total_records_count_header, only: [:create, :delete]
+  end
+
+  def set_total_records_count_header
+    response.headers["X-CM-Total-Records-Count"] = Record.count
+  end
+end

--- a/app/controllers/marc_file_controller.rb
+++ b/app/controllers/marc_file_controller.rb
@@ -1,13 +1,18 @@
 require "centralized_metadata"
 
 class MarcFileController < ApplicationController
+
+  include TotalRecordsCountHeader
+  include RecordsProcessedCountHeader
+
   rescue_from Exception do |exception|
     render json: exception, status: :unprocessable_entity
   end
 
   def delete
     ids = get_ids(params)
-    render json: Record.where(id: ids).destroy_all
+    @records = Record.where(id: ids).destroy_all
+    render json: @records
   end
 
   def ids

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
 require "centralized_metadata"
 
 class RecordsController < ApplicationController
+  include TotalRecordsCountHeader
+  include RecordsProcessedCountHeader
+
   before_action :set_record, only: %i[ show update destroy ]
 
   # GET /records
@@ -18,7 +22,9 @@ class RecordsController < ApplicationController
     params.permit(:marc_file)
 
     marc_file = params[:marc_file].tempfile
-    CentralizedMetadata::Indexer.ingest(marc_file, { original_filename: params[:marc_file].original_filename })
+    options = { original_filename: params[:marc_file].original_filename }
+    @records = CentralizedMetadata::Indexer.ingest(marc_file, options)
+    render json: @records
   end
 
   # PATCH/PUT /records/1
@@ -32,12 +38,6 @@ class RecordsController < ApplicationController
 
     if id != cm_id
       @record.errors.add(:cm_id, "The :cm_id and :id values must match.")
-    end
-
-    # Somtimes the JSON string is not evaluated.
-    # Maybe just in the test environment?
-    if @record.value.is_a? String
-      @record.value = JSON.parse(@record.value)
     end
 
     if @record.errors.blank?
@@ -58,13 +58,19 @@ class RecordsController < ApplicationController
 
   # DELETE /records/1
   def destroy
-    @record.destroy
+   render json: @record.destroy
   end
 
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_record
       @record = Record.find(params[:id])
+
+      # Somtimes the JSON string is not evaluated.
+      # Maybe just in the test environment?
+      if @record.value.is_a? String
+        @record.value = JSON.parse(@record.value)
+      end
     end
 
     # Only allow a list of trusted parameters through.

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -14,3 +14,21 @@ Rswag::Ui.configure do |c|
   # c.basic_auth_enabled = true
   # c.basic_auth_credentials 'username', 'password'
 end
+
+# TODO: Remove once following issue gets resolved and we can configure ourselves without this monkey-patch.
+# https://github.com/rswag/rswag/issues/704
+module ResponseValidator
+  def validation_options_from(metadata)
+    is_strict = !!metadata.fetch(
+      :swagger_strict_schema_validation,
+      @config.swagger_strict_schema_validation
+    )
+
+    {
+      struct: is_strict,
+      noAdditionalProperties: true
+    }
+  end
+end
+
+Rswag::Specs::ResponseValidator.prepend ResponseValidator

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -47,17 +47,23 @@ RSpec.configure do |config|
           }
         }],
 
+                #The property '#/0' contained undefined properties: 'cm_created_at, cm_updated_at, local_metadatum'
         components: {
           schemas: {
             Record: {
               type: "object",
-              required: %w(cm_id),
               properties: CentralizedMetadata::Indexer.fields.reduce({}) { |acc, f|
                 acc.merge("#{f}": {
                   type: "array",
                   items: { type: "string" },
                 })
-              }
+              }.merge({
+                "cm_created_at": { type: "string", format: "date" },
+                "cm_updated_at": { type: "string", format: "date" },
+                "local_metadatum": { "$ref" => "#/components/schemas/LocalMetadatum", "x-nullable": true }
+
+              }),
+              required: [ "cm_id" ],
             },
             Records: {
               type: "array",
@@ -80,6 +86,13 @@ RSpec.configure do |config|
             LocalVarLabels: {
               type: "array",
               items: { "$ref" => "#/components/schemas/LocalVarLabel" }
+            },
+            LocalMetadatum: {
+              type: "object",
+              properties: {
+                local_notes: { type: :array, "$ref" => "#/components/schemas/LocalNotes" },
+                local_var_labels: { type: :array, "$ref" => "#/components/schemas/LocalVarLabels" },
+              }
             },
           }
         }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -366,6 +366,15 @@ paths:
           description: unsuccessful
         '200':
           description: successful
+          headers:
+            X-CM-Records-Processed-Count:
+              schema:
+                type: integer
+              description: The number of records processed.
+            X-CM-Total-Records-Count:
+              schema:
+                type: integer
+              description: The total number of records int the database.
           content:
             application/json:
               schema:
@@ -394,6 +403,12 @@ paths:
           description: unsuccessful
         '200':
           description: successful
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
       requestBody:
         content:
           multipart/form-data:
@@ -434,6 +449,15 @@ paths:
       responses:
         '200':
           description: successful
+          headers:
+            X-CM-Records-Processed-Count:
+              schema:
+                type: integer
+              description: The number of records processed.
+            X-CM-Total-Records-Count:
+              schema:
+                type: integer
+              description: The total number of records int the database.
           content:
             application/json:
               schema:
@@ -549,6 +573,10 @@ paths:
       responses:
         '200':
           description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Record"
 servers:
 - url: https://centralized-metadata-qa.k8s.temple.edu
 - url: http://localhost:3000
@@ -564,8 +592,6 @@ components:
   schemas:
     Record:
       type: object
-      required:
-      - cm_id
       properties:
         cm_id:
           type: array
@@ -815,6 +841,17 @@ components:
           type: array
           items:
             type: string
+        cm_created_at:
+          type: string
+          format: date
+        cm_updated_at:
+          type: string
+          format: date
+        local_metadatum:
+          "$ref": "#/components/schemas/LocalMetadatum"
+          x-nullable: true
+      required:
+      - cm_id
     Records:
       type: array
       items:
@@ -845,3 +882,12 @@ components:
       type: array
       items:
         "$ref": "#/components/schemas/LocalVarLabel"
+    LocalMetadatum:
+      type: object
+      properties:
+        local_notes:
+          type: array
+          "$ref": "#/components/schemas/LocalNotes"
+        local_var_labels:
+          type: array
+          "$ref": "#/components/schemas/LocalVarLabels"


### PR DESCRIPTION
This work is a follow up to my meeting with Holly and makes related changes:

* A lot of the /records endpoints tests were not actually validating the response and would not return an error in testing  when the app returns an empty string even though the API spec says it should return a list of records.  This was happening because we were not invoking the command `run_test!` which is what caused the repose to be validated against the configuration.

* I removed rswag-specs as a separate gem because in fact rswag comes it's own copy of this gem built in.

* I added a monkey patch for an rswag-spec validation method because there is a bug that makes all fields required even though we only made specific fields required.

* I added two headers to the response of record creation and deletion to keep track of how many total records there are in the database after we ingest or post for deletion a marc record, and to track how many records were processed in that instance.

* I updated the ingest process not to delete records that are duplicates but instead update them.

* I update some of the API documentation by adding missing object definition (local_metadatum) which was being caught as missing once proper response validation was happening.

* I updated the delete records to return a list of deleted records.