### PR TITLE
CMR-21 Add additional fields using extract_marc_subfields

### DIFF
--- a/lib/centralized_metadata/indexer_config.rb
+++ b/lib/centralized_metadata/indexer_config.rb
@@ -55,12 +55,15 @@ to_field "cm_alternative_medium_performance", extract_marc("382p")
 to_field "cm_original_key", extract_original_key
 to_field "cm_transposed_key", extract_marc("384|1*|a")
 to_field "cm_music_num_designation", extract_marc_subfields("383abcde")
-to_field "cm_audience_characteristics", default("discussion")
-to_field "cm_characteristics", default("discussion")
+# future work for cm_audience_characteristics: handle repeated subfields as a separate instances of Solr field
+to_field "cm_audience_characteristics", extract_marc_subfields("385a")
+# future work for cm_characteristics: handle repeated subfields as a separate instances of Solr field
+to_field "cm_characteristics", extract_marc_subfields("386a")
 to_field "cm_work_time_creation", extract_work_time_creation
 to_field "cm_aggwork_time_creation", extract_marc("388|2*|a")
 to_field "cm_work_language", extract_marc("100l:110l:111l:130l")
-to_field "cm_notmusic_format", default("discussion")
+# future work for cm_notmusic_format: handle repeated subfields as a separate instances of Solr field
+to_field "cm_notmusic_format", extract_marc_subfields("348a")
 to_field "cm_beginning_date_created", extract_marc("046k")
 to_field "cm_ending_date_created", extract_marc("046l")
 to_field "cm_place_origin_work", extract_marc("370g")

--- a/spec/lib/centralized_metadata/indexer_spec.rb
+++ b/spec/lib/centralized_metadata/indexer_spec.rb
@@ -67,10 +67,7 @@ RSpec.describe CentralizedMetadata::Indexer do
            "cm_type"=>["personal name"],
            "cm_see_also"=>
            ["Biographical and program notes by Stanley Dance ([2] p. : 1 port.) in container; personnel and original issue and matrix no. on container.",
-            "Louis Armstrong, trumpet and vocals, and his band."],
-            "cm_audience_characteristics"=>["discussion"],
-            "cm_characteristics"=>["discussion"],
-            "cm_notmusic_format"=>["discussion"]}])
+            "Louis Armstrong, trumpet and vocals, and his band."]}])
       end
     end
 


### PR DESCRIPTION
This is setting up cm_audience_characteristics, cm_characteristics, and cm_notmusic_format using extract_marc_subfields. Eventually we want to add these mappings to treat any repeated subfields as a separate instance of the applicable field, but this initial step is sufficient for the MVP. 

