### PR TITLE
CMR-21 Update select fields to default extract_marc

### DIFF
--- a/lib/centralized_metadata/indexer_config.rb
+++ b/lib/centralized_metadata/indexer_config.rb
@@ -55,15 +55,12 @@ to_field "cm_alternative_medium_performance", extract_marc("382p")
 to_field "cm_original_key", extract_original_key
 to_field "cm_transposed_key", extract_marc("384|1*|a")
 to_field "cm_music_num_designation", extract_marc_subfields("383abcde")
-# future work for cm_audience_characteristics: handle repeated subfields as a separate instances of Solr field
-to_field "cm_audience_characteristics", extract_marc_subfields("385a")
-# future work for cm_characteristics: handle repeated subfields as a separate instances of Solr field
-to_field "cm_characteristics", extract_marc_subfields("386a")
+to_field "cm_audience_characteristics", extract_marc("385a")
+to_field "cm_characteristics", extract_marc("386a")
 to_field "cm_work_time_creation", extract_work_time_creation
 to_field "cm_aggwork_time_creation", extract_marc("388|2*|a")
 to_field "cm_work_language", extract_marc("100l:110l:111l:130l")
-# future work for cm_notmusic_format: handle repeated subfields as a separate instances of Solr field
-to_field "cm_notmusic_format", extract_marc_subfields("348a")
+to_field "cm_notmusic_format", extract_marc("348a")
 to_field "cm_beginning_date_created", extract_marc("046k")
 to_field "cm_ending_date_created", extract_marc("046l")
 to_field "cm_place_origin_work", extract_marc("370g")

--- a/spec/lib/centralized_metadata/indexer_config_spec.rb
+++ b/spec/lib/centralized_metadata/indexer_config_spec.rb
@@ -133,4 +133,21 @@ RSpec.describe "Traject configuration" do
       end
     end
   end
+
+  describe "check that spec with single subfield splits" do
+
+    context "385a field with one subfield a" do
+      it "output single cm_audience_characteristics instance" do
+        record.append(MARC::DataField.new("385", nil, nil, ["a", "Lawyers"]))
+        expect(indexer.map_record(record)["cm_audience_characteristics"].count).to eq(1)
+      end
+    end
+    
+    context "385a field with two subfield a" do
+      it "output two cm_audience_characteristics field instance" do
+        record.append(MARC::DataField.new("385", nil, nil, ["a", "Lawyers"], ["a", "Judges"]))
+        expect(indexer.map_record(record)["cm_audience_characteristics"].count).to eq(2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Upon further review of the traject documentation, it turns out that extract_marc will split a specification with a single subfield, which is the desired behavior for cm_audience_characteristics, cm_characteristics, and cm_notmusic_format. 

From https://github.com/traject/traject/blob/master/README.md: "Specifications with single subfields (like "020a") will split subfields and produce an output string for each matching subfield (i.e. two output strings for a single '020' with two subfield 'a')."