### PR TITLE
Update tzdata, postgresql and bash packages.

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -9,9 +9,9 @@ USER root
 ARG RAILS_ENV=production
 
 RUN apk add -U --no-cache \
-      bash=5.2.26-r0 \
-      tzdata=2024b-r0 \
-      postgresql16-client=16.5-r0 \
+      bash=5.2.37-r0 \
+      tzdata=2024b-r1 \
+      postgresql16-client=16.6-r0 \
       gcompat=1.1.0-r4 \
       libxslt=1.1.39-r1 && \
     apk add -U --no-cache --virtual build-dependencies \


### PR DESCRIPTION
Fixes:

0.743 ERROR: unable to select packages:
0.744   bash-5.2.37-r0:
0.744     breaks: world[bash=5.2.26-r0]
0.744   libxslt-1.1.42-r1:
0.744     breaks: world[libxslt=1.1.39-r1]
0.744   postgresql16-client-16.6-r0:
0.744     breaks: world[postgresql16-client=16.5-r0]
0.744   tzdata-2024b-r1:
0.744     breaks: world[tzdata=2024b-r0]
